### PR TITLE
Update articles when changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'org.asciidoctor.jvm.gems' version '3.2.0' apply false
     id 'org.asciidoctor.jvm.convert' version '3.2.0' apply false
     id "com.neo4j.gradle.wordpress.WordPressPlugin" version "0.5.0"
-    id "com.neo4j.gradle.zendesk.ZenDeskPlugin" version "0.1.3"
+    id "com.neo4j.gradle.zendesk.ZenDeskPlugin" version "0.2.0"
 }
 
 apply plugin: 'org.asciidoctor.jvm.gems'


### PR DESCRIPTION
The latest version of the Zendesk plugin only updates an article when its content has changed, otherwise the article is skipped:

```
Skipping article with id: 115012460368 and slug: a-demonstration-of-causal-cluster-routing, content has not changed
```

When this pull request will be merged, all articles will be updated to add an MD5 digest of the article data (inside an `<!-- HTML comment -->`). After that, the Zendesk plugin will compare the MD5 to determine if the article needs to be updated or not.