### PR TITLE
Pass the cursor from the document

### DIFF
--- a/resources/extensions/footer.rb
+++ b/resources/extensions/footer.rb
@@ -16,7 +16,7 @@ module Neo4j
        def process(document, reader)
          lines = reader.lines
          lines.push(*FOOTER_LINES)
-         Asciidoctor::Reader.new lines
+         Asciidoctor::Reader.new lines, document.reader.cursor
       end
     end
   end


### PR DESCRIPTION
Otherwise an "<stdin>" cursor will be used, and the filename will be missing from the logs!