### PR TITLE
Fix invalid image macros

### DIFF
--- a/articles/modules/ROOT/pages/how-do-i-authenticate-with-cypher-shell-without-specifying-the-username-and-password-on-the-command-line.adoc
+++ b/articles/modules/ROOT/pages/how-do-i-authenticate-with-cypher-shell-without-specifying-the-username-and-password-on-the-command-line.adoc
@@ -33,4 +33,4 @@ Further if using linux, the export commands above could be placed in the user's 
 If using Windows, environment variables can be defined via Control Panel -> System, Advanced tab, [Environment Variables] as 
 pictured below:
 
-image:http://imgur.com/4nfUMcx.png[image width="200" height="400"]
+image:http://imgur.com/4nfUMcx.png[image,width="200",height="400"]

--- a/articles/modules/ROOT/pages/how-do-i-determine-number-of-nodes-and-relationships-effected-by-detach-delete.adoc
+++ b/articles/modules/ROOT/pages/how-do-i-determine-number-of-nodes-and-relationships-effected-by-detach-delete.adoc
@@ -16,13 +16,13 @@ match (n:Person) return count(n), sum ( size( (n)-[]->()));
 
 this will report back
 
-image:https://imgur.com/SMbR6Ll.png[[image]
+image::https://imgur.com/SMbR6Ll.png[image]
 
 which would indicate that if you are to then run  `match (n:Person) detach delete n;` this will effect 
 
 133 nodes and 253 relationships and as depicted
 
-image:https://imgur.com/acGdh8R.png[image]
+image::https://imgur.com/acGdh8R.png[image]
 
 
 In this case the 133 nodes and 253 relationships is not a significantly large number.  

--- a/articles/modules/ROOT/pages/how-neo4j-browser-bolt-routing.adoc
+++ b/articles/modules/ROOT/pages/how-neo4j-browser-bolt-routing.adoc
@@ -30,7 +30,9 @@ Please note that in order for bolt+routing to work correctly the current user mu
 
 Symptom: you can connect to Neo4j Browser and enter credentials, but fail to connect with a message about WebSocket connection failures.
 
-It looks like this: https://imgur.com/3Y7NBDg.png
+It looks like this:
+
+image::https://imgur.com/3Y7NBDg.png[]
 
 Explanation: this is commonly seen with Firefox and some versions of Internet Explorer, when Neo4j Browser is used with an untrusted
 SSL certificate. When users click to accept the exception and permit traffic, those browsers authorize that action for only the port

--- a/articles/modules/ROOT/pages/how-to-avoid-costly-traversals-with-join-hints.adoc
+++ b/articles/modules/ROOT/pages/how-to-avoid-costly-traversals-with-join-hints.adoc
@@ -34,7 +34,7 @@ RETURN a, count(a) as likesInCommon
 
 If the planner decides to use only a single starting point for this query and doesn't recognize a potential supernode issue, it's possible that it may choose to plan expansion through the :Artist node, which could be very costly:
 
-image:img/without-join-hint.png[image,role="popup-link"]
+image::https://s3.amazonaws.com/support.neotechnology.com/KBs/without-join-hint.png[image,role="popup-link"]
 
 As the Cypher query planner has the ability to rearrange the ordering of adjacent MATCH patterns (and across some WITH clauses), simply reordering my pattern isn't enough.
 I can use a join hint to ensure we only traverse *to* the node in question, but not through it or away from it.
@@ -48,4 +48,4 @@ RETURN a, count(a) as likesInCommon
 
 From the query plan we can see that from the same starting point we traverse two different paths toward `a`, but not through it, and perform a node hash join to unify the paths on the common artist nodes.
 
-image:img/with-join-hint.png[image,role="popup-link"]
+image::https://s3.amazonaws.com/support.neotechnology.com/KBs/with-join-hint.png[image,role="popup-link"]


### PR DESCRIPTION
Fix a few issues related to the `image:` macro prior to migrating the images from imgur.com to Amazon S3.


@danielterlizzi Could you please review this pull request and merge it?