### PR TITLE
Script to synchronize images to S3

### DIFF
--- a/imgur-replace-image-target.js
+++ b/imgur-replace-image-target.js
@@ -1,0 +1,37 @@
+const path = require('path')
+const fs = require('fs')
+
+const pagesDir = path.join(__dirname, 'articles', 'modules', 'ROOT', 'pages')
+const imgurImageReplaceMacroRx = /(image::?)(https?:\/\/(:?i\.)?imgur.com\/([a-zA-Z0-9]+\.(png|jpe?g)))\[([^\]]*)]/g
+
+;(async () => {
+  try {
+    const asciidocFiles = fs.readdirSync(pagesDir)
+    for (const file of asciidocFiles) {
+      if (file.endsWith('.adoc')) {
+        const filePath = path.join(pagesDir, file);
+        const content = fs.readFileSync(filePath, 'utf8')
+        const lines = content.split(/\r?\n/)
+        const data = []
+        for (const line of lines) {
+          data.push(line.replace(imgurImageReplaceMacroRx, (replace, ...args) => {
+            const imageMacro = args[0]
+            let imageName = args[3]
+            const fileExtension = args[4]
+            const attributesList = args[5]
+            const description = attributesList.split(',')[0]
+            if (description && description !== 'image' && !description.includes('=')) {
+              imageName = description.toLowerCase().replace(/\s/g, '-') + '.' + fileExtension
+            } else {
+              imageName = file.replace(/\.adoc$/, '') + '-' + imageName
+            }
+            return `${imageMacro}${imageName}[${attributesList}]`
+          }))
+        }
+        fs.writeFileSync(filePath, data.join('\n'), 'utf8')
+      }
+    }
+  } catch (err) {
+    console.error('Error', err)
+  }
+})()

--- a/imgur-replace-image-target.js
+++ b/imgur-replace-image-target.js
@@ -25,7 +25,7 @@ const imgurImageReplaceMacroRx = /(image::?)(https?:\/\/(:?i\.)?imgur.com\/([a-z
             } else {
               imageName = file.replace(/\.adoc$/, '') + '-' + imageName
             }
-            return `${imageMacro}${imageName}[${attributesList}]`
+            return `${imageMacro}https://s3.amazonaws.com/dev.assets.neo4j.com/kb-content/${imageName}[${attributesList}]`
           }))
         }
         fs.writeFileSync(filePath, data.join('\n'), 'utf8')

--- a/imgur-sync-to-s3.js
+++ b/imgur-sync-to-s3.js
@@ -1,0 +1,71 @@
+const axios = require('axios')
+const process = require('process')
+const path = require('path')
+const fs = require('fs')
+const execSync = require('child_process').execSync;
+
+const imgurImageMacroRx = /image::?(https?:\/\/(:?i\.)?imgur.com\/([a-zA-Z0-9]+\.(png|jpe?g)))\[([^\]]*)]/g
+const pagesDir = path.join(__dirname, 'articles', 'modules', 'ROOT', 'pages')
+const buildDir = path.join(__dirname, 'build', 's3', 'images')
+fs.mkdirSync(buildDir, { recursive: true })
+
+// clean build/s3/images directory
+const imageFiles = fs.readdirSync(buildDir)
+for (const file of imageFiles) {
+  fs.unlinkSync(path.join(buildDir, file))
+}
+
+async function getImage(url) {
+  console.log(`\tGET ${url}`)
+  return axios({
+    method: 'get',
+    url,
+    responseType: 'stream'
+  })
+}
+
+;(async () => {
+  try {
+    const asciidocFiles = fs.readdirSync(pagesDir)
+    for (const file of asciidocFiles) {
+      if (file.endsWith('.adoc')) {
+        const content = fs.readFileSync(path.join(pagesDir, file), 'utf8')
+        const lines = content.split(/\r?\n/)
+        for (const line of lines) {
+          const matches = [...line.matchAll(imgurImageMacroRx)]
+          if (matches && matches.length > 0) {
+            console.log(`- ${file}`)
+            for (const match of matches) {
+              let imageUrl = match[1]
+              let imageName = match[3]
+              if (imageUrl.startsWith('http://')) {
+                imageUrl = `https://i.imgur.com/${imageName}`
+              }
+              const fileExtension = match[4]
+              const attributesList = match[5]
+              const description = attributesList.split(',')[0]
+              if (description && description !== 'image' && !description.includes('=')) {
+                imageName = description.toLowerCase().replace(/\s/g, '-') + '.' + fileExtension
+              } else {
+                imageName = file.replace(/\.adoc$/, '') + '-' + imageName
+              }
+              const response = await getImage(imageUrl)
+              const imagePath = path.join(buildDir, imageName)
+              console.log(`\twriting image to ${imagePath}`)
+              response.data.pipe(fs.createWriteStream(imagePath))
+            }
+          }
+        }
+      }
+    }
+    const profileOption = process.env.AWS_PROFILE ? ` --profile ${process.env.AWS_PROFILE}` : ''
+    const awsS3SyncCommand = `aws s3 sync . s3://support.neotechnology.com/KBs --acl public-read${profileOption}`;
+    console.log(awsS3SyncCommand)
+    const result = execSync(awsS3SyncCommand, {
+      cwd: buildDir
+    })
+    console.log(result.toString('utf8'))
+  } catch (err) {
+    console.error('Error', err)
+  }
+})()

--- a/imgur-sync-to-s3.js
+++ b/imgur-sync-to-s3.js
@@ -59,7 +59,7 @@ async function getImage(url) {
       }
     }
     const profileOption = process.env.AWS_PROFILE ? ` --profile ${process.env.AWS_PROFILE}` : ''
-    const awsS3SyncCommand = `aws s3 sync . s3://support.neotechnology.com/KBs --acl public-read${profileOption}`;
+    const awsS3SyncCommand = `aws s3 sync . s3://dev.assets.neo4j.com/kb-content --acl public-read${profileOption}`;
     console.log(awsS3SyncCommand)
     const result = execSync(awsS3SyncCommand, {
       cwd: buildDir

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "knowledge-base-public",
+  "name": "@neo4j/knowledge-base",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -318,45 +318,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "backo2": {
@@ -2521,6 +2488,48 @@
         "yargs": "13.3.0"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "yargs": {
           "version": "13.3.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@antora/cli": "^2.3.4",
     "@antora/site-generator-default": "^2.3.4",
+    "axios": "^0.20.0",
     "browser-sync": "^2.26.12",
     "cheerio": "^1.0.0-rc.3",
     "chokidar": "^3.4.2",

--- a/s3-support-replace-image-target.js
+++ b/s3-support-replace-image-target.js
@@ -1,0 +1,30 @@
+const path = require('path')
+const fs = require('fs')
+
+const pagesDir = path.join(__dirname, 'articles', 'modules', 'ROOT', 'pages')
+const imgurImageReplaceMacroRx = /(image::?)(https:\/\/s3.amazonaws.com\/support.neotechnology.com\/KBs\/([^.]+\.(png|jpe?g)))\[([^\]]*)]/g
+
+;(async () => {
+  try {
+    const asciidocFiles = fs.readdirSync(pagesDir)
+    for (const file of asciidocFiles) {
+      if (file.endsWith('.adoc')) {
+        const filePath = path.join(pagesDir, file);
+        const content = fs.readFileSync(filePath, 'utf8')
+        const lines = content.split(/\r?\n/)
+        const data = []
+        for (const line of lines) {
+          data.push(line.replace(imgurImageReplaceMacroRx, (replace, ...args) => {
+            const imageMacro = args[0]
+            let imageName = args[2]
+            const attributesList = args[4]
+            return `${imageMacro}https://s3.amazonaws.com/dev.assets.neo4j.com/kb-content/${imageName}[${attributesList}]`
+          }))
+        }
+        fs.writeFileSync(filePath, data.join('\n'), 'utf8')
+      }
+    }
+  } catch (err) {
+    console.error('Error', err)
+  }
+})()

--- a/s3-support-sync-to-s3-dev.js
+++ b/s3-support-sync-to-s3-dev.js
@@ -1,0 +1,60 @@
+const axios = require('axios')
+const process = require('process')
+const path = require('path')
+const fs = require('fs')
+const execSync = require('child_process').execSync;
+
+const s3ImageMacroRx = /image::?(https:\/\/s3.amazonaws.com\/support.neotechnology.com\/KBs\/([^.]+\.(png|jpe?g)))\[([^\]]*)]/g
+const pagesDir = path.join(__dirname, 'articles', 'modules', 'ROOT', 'pages')
+const buildDir = path.join(__dirname, 'build', 's3', 'images')
+fs.mkdirSync(buildDir, { recursive: true })
+
+// clean build/s3/images directory
+const imageFiles = fs.readdirSync(buildDir)
+for (const file of imageFiles) {
+  fs.unlinkSync(path.join(buildDir, file))
+}
+
+async function getImage(url) {
+  console.log(`\tGET ${url}`)
+  return axios({
+    method: 'get',
+    url,
+    responseType: 'stream'
+  })
+}
+
+;(async () => {
+  try {
+    const asciidocFiles = fs.readdirSync(pagesDir)
+    for (const file of asciidocFiles) {
+      if (file.endsWith('.adoc')) {
+        const content = fs.readFileSync(path.join(pagesDir, file), 'utf8')
+        const lines = content.split(/\r?\n/)
+        for (const line of lines) {
+          const matches = [...line.matchAll(s3ImageMacroRx)]
+          if (matches && matches.length > 0) {
+            console.log(`- ${file}`)
+            for (const match of matches) {
+              let imageUrl = match[1]
+              let imageName = match[2]
+              const response = await getImage(imageUrl)
+              const imagePath = path.join(buildDir, imageName)
+              console.log(`\twriting image to ${imagePath}`)
+              response.data.pipe(fs.createWriteStream(imagePath))
+            }
+          }
+        }
+      }
+    }
+    const profileOption = process.env.AWS_PROFILE ? ` --profile ${process.env.AWS_PROFILE}` : ''
+    const awsS3SyncCommand = `aws s3 sync . s3://dev.assets.neo4j.com/kb-content --acl public-read${profileOption}`;
+    console.log(awsS3SyncCommand)
+    const result = execSync(awsS3SyncCommand, {
+      cwd: buildDir
+    })
+    console.log(result.toString('utf8'))
+  } catch (err) {
+    console.error('Error', err)
+  }
+})()


### PR DESCRIPTION
### Prerequisites

Install the latest LTS version of [Node.js](https://nodejs.org).
The migration relies on the `aws` CLI and more precisely on the `aws s3 sync` command: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html

Make sure that the AWS CLI is correctly installed, configured and available in your `PATH`.

### Procedure

#### Install the dependencies

```
$ npm i
```

#### Migrate images from imgur.com to Amazon S3


```
$ node imgur-sync-to-s3.js 
```

If you want to use a specific AWS profile, use the `AWS_PROFILE` environment variable:

```
$ AWS_PROFILE=neo4j node imgur-sync-to-s3.js 
```

> A named profile is a collection of settings and credentials that you can apply to a AWS CLI command. When you specify a profile to run a command, the settings and credentials are used to run that command. You can specify one profile that is the "default", and is used when no profile is explicitly referenced. Other profiles have names that you can specify as a parameter on the command line for individual commands. Alternatively, you can specify a profile in an environment variable (AWS_PROFILE) which essentially overrides the default profile for commands that run in that session.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

Once the script has been executed successful, check that the images are available under https://s3.amazonaws.com/dev.assets.neo4j.com/kb-content

#### Update the KB articles

```
$ node imgur-replace-image-target.js
```

#### Local check

Convert the articles to HTML using the `convert` Gradle task:

```
$ ./gradlew convert
```

Then, open the HTML pages in your browser and make sure that the images are correctly displayed.
Commit the changes.


