### PR TITLE
Replace remove-gradle-command-action with built-in run action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Test
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: convertWordPressHtml
-    - name: Test
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: convert
+    - name: Convert
+      run: |
+        ./gradlew convert


### PR DESCRIPTION
Also `convertWordPressHtml` was called twice because the `convert` task will call both `convertWordPressHtml` and `convertZenDeskHtml`.