### PR TITLE
Replace old, obsolete github link with new link

### DIFF
--- a/articles/modules/ROOT/pages/conditional-cypher-execution.adoc
+++ b/articles/modules/ROOT/pages/conditional-cypher-execution.adoc
@@ -160,7 +160,7 @@ Remember that any other non-write clause, such as MATCH, WITH, and CALL, cannot 
 
 == APOC conditional procedures
 
-Alternately, the APOC Procedures library includes procedures designed for http://neo4j-contrib.github.io/neo4j-apoc-procedures/3.5/cypher-execution/conditionals/[conditional Cypher execution].
+Alternately, the APOC Procedures library includes procedures designed for https://neo4j.com/labs/apoc/4.2/cypher-execution/running-cypher/[conditional Cypher execution].
 
 There are two types of procedures:
 


### PR DESCRIPTION
Replaced obsolete link:

http://neo4j-contrib.github.io/neo4j-apoc-procedures/3.5/cypher-execution/conditionals/

with 

https://neo4j.com/labs/apoc/4.2/cypher-execution/running-cypher/

which is where the first link redirects to.