### PR TITLE
Fix branch name in notify workflow

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -3,7 +3,7 @@ name: Notify Antora
 on:
   push:
     branches:
-      - publish
+      - master
 
 jobs:
   notify:


### PR DESCRIPTION
Changes on main branch (`master`) should notify the `neo4j-documentation/docs-refresh` repository in order to publish new or updated content on https://neo4j.com/developer/kb