### PR TITLE
Use a version (v1) instead of a 'deprecated' branch name

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Notify Antora
-        uses: peter-evans/repository-dispatch@master
+        uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.BUILD_ACCESS_TOKEN }}
           repository: neo4j-documentation/docs-refresh


### PR DESCRIPTION
The GitHub Action `peter-evans/repository-dispatch` has renamed the default branch from `master` to `main`.

We have the following warnings when the action is running:

```
peter-evans/repository-dispatch@master
Warning: This action's default branch has been renamed to "main"
Warning: Referencing this action with "@master" is deprecated and will stop working after June 30th 2021
```

https://github.com/neo4j-documentation/knowledge-base/runs/3749795275?check_suite_focus=true

Despite the warning message, the action is still running fine but to avoid issues it's better to use a tag name `v1` instead of a branch name `master`.