### PR TITLE
Add driver 4.4 to the Supported Versions list

### DIFF
--- a/articles/modules/ROOT/pages/neo4j-supported-versions.adoc
+++ b/articles/modules/ROOT/pages/neo4j-supported-versions.adoc
@@ -14,11 +14,11 @@ Neo4j Database Enterprise Edition
 [options=header]
 |===
 |Release |Release Date |End of Support Date |Compatible Driver Versions 
-|[white]*4.3* |[white]*June 17, 2021* |[white]*December 16, 2022* |[white]*4.3, 4.2, 4.1, 4.0* 
-|[white]*4.2* |[white]*November 17, 2020* |[white]*May 16, 2022* |[white]*4.3, 4.2, 4.1, 4.0* 
-|[white]*4.1* |[white]*June 23, 2020* |[white]*December 22, 2021* |[white]*4.3, 4.2, 4.1, 4.0* 
-|[white]*4.0* |[white]*January 15, 2020* |[white]*July 14, 2021* |[white]*4.3, 4.2, 4.1, 4.0* 
-|[white]*3.5*(n1) |[white]*November 29, 2018* |[white]*May 27, 2022* (n3) |[white]*4.3, 4.2, 4.1, 4.0, 1.7* 
+|[white]*4.3* |[white]*June 17, 2021* |[white]*December 16, 2022* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
+|[white]*4.2* |[white]*November 17, 2020* |[white]*May 16, 2022* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
+|[white]*4.1* |[white]*June 23, 2020* |[white]*December 22, 2021* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
+|[white]*4.0* |[white]*January 15, 2020* |[white]*July 14, 2021* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
+|[white]*3.5*(n1) |[white]*November 29, 2018* |[white]*May 27, 2022* (n3) |[white]*4.4, 4.3, 4.2, 4.1, 4.0, 1.7* 
 |[white]*3.4* |[white]*May 17, 2018* |[white]*March 31, 2020* (n2) |[white]*1.7, 1.6* 
 |[white]*3.3* |[white]*October 24, 2017* |[white]*April 28, 2019* |[white]*1.7, 1.6, 1.5, 1.4* 
 |[white]*3.2* |[white]*May 11, 2017* |[white]*November 31, 2018* |[white]*1.6, 1.5, 1.4, 1.3* 


### PR DESCRIPTION
As per discussion in #team-drivers, Driver version 4.4 should support the same versions as 4.3 drivers, but needs Server 4.4 for newer features