### PR TITLE
Should say MATCH instead of MERGE

### DIFF
--- a/articles/modules/ROOT/pages/understanding-how-merge-works.adoc
+++ b/articles/modules/ROOT/pages/understanding-how-merge-works.adoc
@@ -69,7 +69,7 @@ MATCH (class:Class{name:'Cypher101'})
 MERGE (student)-[:ENROLLED_IN]->(class)
 ----
 
-Similarly, you could MERGE on the student and class prior to the MERGE on the relationship between them.
+Similarly, you could MATCH on the student and class prior to the MERGE on the relationship between them.
 
 [source,cypher]
 ----


### PR DESCRIPTION
Should say 'MATCH on the student and class prior to the MERGE' instead of 'MERGE on the student and class prior to the MERGE'