### PR TITLE
Updated intracluster ssl kb

### DIFF
--- a/articles/modules/ROOT/pages/a-demonstration-of-intracluster-ssl-encryption.adoc
+++ b/articles/modules/ROOT/pages/a-demonstration-of-intracluster-ssl-encryption.adoc
@@ -1,6 +1,6 @@
 = A demonstration of IntraCluster SSL Encryption
 :slug: a-demonstration-of-intracluster-ssl-encryption
-:author: Umar Muzammil
+:author: Umar Muzammil, Sandeep Reehall
 :category: cluster
 :tags: ssl, tls, certificate, causal-cluster, encryption
 :neo4j-versions: 3.5, 4.0, 4.1, 4.2, 4.3, 4.4
@@ -13,30 +13,42 @@ instances of a Causal Cluster, aimed at achieving intra-cluster encryption. The 
 * Configure Causal Clustering with the SSL policy
 * Validate the secure operation of the cluster
  
-These are further described in the NEO4J operations manual:
+These are further described in the Neo4j operations manual:
 https://neo4j.com/docs/operations-manual/current/clustering/intra-cluster-encryption/#intra-cluster-encryption-example-deployment
 
 Lets go through the demonstration of creation, deployment and verification of the SSL certificate.
 
-*INSTALL OPENSSL*
+== Install OpenSSL
 
-A certificate can be signed by a trusted Certificate Authority (CA) or, as in this case, be a self-signed one. Lets first 
-see how we can create a self-signed certificate with OpenSSL. We'll first need to install OpenSSL in order to create a 
-self-signed certificate. While Linux distributions usually have OpenSSL pre-installed, this is not the case for Windows, 
-where this can be achieved using a Windows binary. Some sample binaries are available at the below links:
+A certificate can be signed by a trusted Certificate Authority (CA) or, as in this case, be a self-signed one. We will create a self-signed certificate using OpenSSL. We'll first need to install OpenSSL in order to create a self-signed certificate.
+
+=== Windows
+
+OpenSSL can be installed using a Windows binary. Some sample binaries are available at the below links:
 
 https://wiki.openssl.org/index.php/Binaries
-https://www.cloudinsidr.com/content/how-to-install-the-most-recent-version-of-openssl-on-windows-10-in-64-bit/
 
+=== Linux
 
-On OSX, one can install OpenSSL using macports, as described here: https://www.macports.org/install.php
+Many Linux distributions has OpenSSL installed. If this is not the case, use a package manager to install openssl, for example:
 
-For purposes of this demonstration, homebrew was used as below:
+[source,shell]
+----
+$ sudo apt-get install openssl
+----
+
+=== Mac
+
+On OSX, OpenSSL can be installed using macports, as described here: https://www.macports.org/install.php
+
+Or alternatively via homebrew package manager as below:
 
 [source,shell]
 ----
 $ brew install openssl
 ----
+
+=== Verify Installation
 
 Once installed, the version and installation directory, amongst other installation features, can be checked by running `brew info openssl`,
 or `openssl version -a`:
@@ -44,25 +56,38 @@ or `openssl version -a`:
 [source,shell,role=noheader]
 ----
 $ openssl version -a
-OpenSSL 1.0.2o  27 Mar 2018
-built on: reproducible build, date unspecified
-platform: darwin64-x86_64-cc
-options:  bn(64,64) rc4(ptr,int) des(idx,cisc,16,int) idea(int) blowfish(idx) 
-compiler: /usr/bin/clang -I. -I.. -I../include  -fPIC 
--fno-common -DOPENSSL_PIC -DZLIB -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -arch x86_64 -O3 -DL_ENDIAN -Wall
--DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM
--DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM -DECP_NISTZ256_ASM
-OPENSSLDIR: "/opt/local/etc/openssl"
+LibreSSL 2.8.3
+built on: date not available
+platform: information not available
+options:  bn(64,64) rc4(16x,int) des(idx,cisc,16,int) blowfish(idx)
+compiler: information not available
+OPENSSLDIR: "/private/etc/ssl"
 ----
 
-*CREATE THE SSL CERTIFICATE AND KEY*
+== Create a Neo4j SSL Framework directory structure
 
-We can then add the installation directory to PATH as `echo 'export PATH="/usr/local/opt/openssl/bin:$PATH"' >> ~/.bash_profile` 
+https://neo4j.com/docs/operations-manual/current/security/ssl-framework[Neo4j SSL Framework] requires the following directory structure be created:
 
-Lets finally get to creating our certificate and key:
+[source,shell,role=noheader]
+----
+<NEO4J_HOME>/certificates
+                └── cluster
+                    ├── revoked
+                    └── trusted
+----
 
-In terminal, change the current directory to the openssl installation directory (in this case, /opt/local/bin) and run the 
-command below:
+From <NEO4J_HOME> run the following commands to create the above structure:
+
+[source,shell]
+---
+$ mkdir certificates/cluster
+$ mkdir certificates/cluster/trusted
+$ mkdir certificates/cluster/revoked
+---
+
+== Create the SSL Certificate and Key
+
+Use the following command to create a certificate `cert.pem` and a key `key.pem` making sure to change `xxx` to the number of days the certificates should be valid for:
 
 [source,shell]
 ----
@@ -112,84 +137,81 @@ Common Name (e.g. server FQDN or YOUR name) []:CS
 Email Address []:myemail@email.com
 ----
 
-Above creates the cert.pem and key.pem files in the current directory. 
-
-Below commands then generate the public.crt and private.key files, using the .pem files created above:
+The below commands then generate the `public.crt` and `private.key` files, using the .pem files created above:
 
 [source,shell]
 ----
-$ sudo openssl x509 -outform der -in cert.pem -out public.crt
+$ sudo openssl x509 -outform pem -in cert.pem -out public.crt
 $ openssl rsa -in key.pem -out private.key
 ----
 
-*DEPLOYING THE SSL CERTIFICATE AND KEY*
+== DEPLOYING THE SSL CERTIFICATE AND KEY
 
-Place the above created private.key in $NEO4J_HOME/certificates/cluster and public.crt in $NEO4J_HOME/certificates/cluster/trusted, 
-then add the following to neo4j.conf of each instance in the cluster:
+Place the above created `private.key` and `public.crt` in `$NEO4J_HOME/certificates/cluster`. Then place `public.crt` in $NEO4J_HOME/certificates/cluster/trusted:
+
+[source,shell,role=noheader]
+----
+certificates
+└── cluster
+    ├── private.key
+    ├── public.crt
+    ├── revoked
+    └── trusted
+        └── public.crt
+----
+
+Then add the following to neo4j.conf of each instance in the cluster, making sure to replace `<<Absolute_Path_Of_$NEO4J_HOME>>` appropriately:
 
 [source,properties]
 ----
-causal_clustering.ssl_policy=cluster
-dbms.ssl.policy.cluster.base_directory=Absolute_Path_Of_$NEO4J_HOME/certificates/cluster
-dbms.ssl.policy.default.base_directory=Absolute_Path_Of_$NEO4J_HOME/certificates/cluster
-dbms.ssl.policy.default.trusted_dir=Absolute_Path_Of_$NEO4J_HOME/certificates/cluster/trusted
-dbms.ssl.policy.default.revoked_dir=Absolute_Path_Of_$NEO4J_HOME/certificates/cluster/revoked
-dbms.ssl.policy.default.client_auth=NONE
+dbms.ssl.policy.cluster.enabled=true
+dbms.ssl.policy.cluster.base_directory=<<Absolute_Path_Of_$NEO4J_HOME>>/certificates/cluster
+dbms.ssl.policy.default.base_directory=<<Absolute_Path_Of_$NEO4J_HOME>>/certificates/cluster
+dbms.ssl.policy.default.trusted_dir=<<Absolute_Path_Of_$NEO4J_HOME>>/certificates/cluster/trusted
+dbms.ssl.policy.default.revoked_dir=<<Absolute_Path_Of_$NEO4J_HOME>>/certificates/cluster/revoked
 dbms.ssl.policy.cluster.ciphers=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
 dbms.ssl.policy.cluster.client_auth=REQUIRE
 ----
 
-*VALIDATE THE INTRACLUSTER ENCRYPTION*
+== Validate the Intra-cluster Encryption
 
 We're now ready to initialise all cluster instances. Once these are initialised and available, we can then verify our SSL encryption
-by using the nmap tool (deployed alongside openssl), to check the available SSL ciphers as below:
+by using the nmap tool (sometimes deployed alongside openssl otherwise it will need to be installed separately), to check the available SSL ciphers as below:
 
 [source,shell,role=noheader]
 ----
-$ nmap --script ssl-enum-ciphers -p 7470 localhost
-Starting Nmap 7.70 ( https://nmap.org ) at 2019-05-30 12:39 BST
+$ nmap --script ssl-enum-ciphers -p 5000 localhost
+Starting Nmap 7.80 ( https://nmap.org ) at 2022-07-07 14:18 UTC
 Nmap scan report for localhost (127.0.0.1)
-Host is up (0.00022s latency).
+Host is up (0.000049s latency).
 Other addresses for localhost (not scanned): ::1
 
 PORT     STATE SERVICE
-7470/tcp open  unknown
-| ssl-enum-ciphers: 
-|   TLSv1.2: 
-|     ciphers: 
+5000/tcp open  upnp
+| ssl-enum-ciphers:
+|   TLSv1.2:
+|     ciphers:
 |       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (secp256r1) - A
-|       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 2048) - A
-|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
-|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
-|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
-|       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
-|       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
-|     compressors: 
+|     compressors:
 |       NULL
-|     cipher preference: server
+|     cipher preference: indeterminate
+|     cipher preference error: Too few ciphers supported
+|     warnings:
+|       Key exchange (secp256r1) of lower strength than certificate key
 |_  least strength: A
 
-Nmap done: 1 IP address (1 host up) scanned in 0.54 seconds
+Nmap done: 1 IP address (1 host up) scanned in 0.31 seconds
 ----
 
-Where port 7470 in this case is the `dbms.connector.https.advertised_address:port`. An additional confirmation would be to find debug messages
+Where port `5000` is the default Causal Cluster Discovery Management. The above configuration will also enable SSL on port `6000` and `7000` which are Causal Cluster Transaction and Causal Cluster RAFT ports respectively. Details on Neo4j port usages can be found on the following link:
+
+https://neo4j.com/docs/operations-manual/current/configuration/ports/
+
+An additional confirmation would be to find debug messages
 similar to the following, in the Neo4j debug.log:
 
 ....
-2019-05-30 11:34:47.666+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder] Decoding WebSocket Frame opCode=2
-2019-05-30 11:34:47.666+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder] Decoding WebSocket Frame length=101
-2019-05-30 11:34:47.666+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder] Decoding WebSocket Frame opCode=2
-2019-05-30 11:34:47.666+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder] Decoding WebSocket Frame length=943
-2019-05-30 11:34:47.695+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder] Encoding WebSocket Frame opCode=2 length=8298
-2019-05-30 11:34:47.695+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder] Encoding WebSocket Frame opCode=2 length=114435
-2019-05-30 11:34:47.695+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder] Encoding WebSocket Frame opCode=2 length=2730
-2019-05-30 11:34:47.696+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder] Encoding WebSocket Frame opCode=2 length=31010
-2019-05-30 11:34:47.696+0000 DEBUG [io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder] Encoding WebSocket Frame opCode=2 length=113
+2022-07-08 09:30:28.006+0000 INFO  [o.n.s.c.SslPolicyLoader] Loaded SSL policy 'CLUSTER' = SslPolicy{keyCertChain=Subject: EMAILADDRESS=myemail@email.com, CN=neo4j.local, OU=Support, O=Neo4j, L=London, ST=London, C=UK, Issuer: EMAILADDRESS=myemail@email.com, CN=neo4j.local, OU=Support, O=Neo4j, L=London, ST=London, C=UK, ciphers=[TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384], tlsVersions=[TLSv1.2], clientAuth=REQUIRE}
 ....
 
 References:


### PR DESCRIPTION
Following the kb from start to finished did not work.

There are a number of corrections that needed to be made in this kb. For example:
- deprecriated or incorrect Neo4j properties,
- incorrectly converting to der format in one step
- use nmap to test port 7470 (which is not a cluster port)

These and other issues have been corrected.