### PR TITLE
Neo4j Supported Versions for v5 (inc GA/LA/LTS)

### DIFF
--- a/articles/modules/ROOT/pages/neo4j-supported-versions.adoc
+++ b/articles/modules/ROOT/pages/neo4j-supported-versions.adoc
@@ -15,9 +15,14 @@ Review our https://neo4j.com/terms/support-terms/[Neo4j 5.x Support Terms] for r
 [options=header]
 |===
 |Release |Release Date |Hotfixes until |Compatible Driver Versions 
-|[white]*5.1* |[white]*October 24, 2022* |[white]*Release of 5.2* |[white]*5.x, 4.4*
-|[white]*5.0* |[white]*October 06, 2022* |[white]*October 24, 2022* |[white]*5.x, 4.4*
+|[white]*5.1* `GA` |[white]*October 24, 2022* |[white]*Release of 5.2* |[white]*5.x, 4.4*
+|[white]*5.0* `LA` |[white]*October 06, 2022* |[white]*October 24, 2022* |[white]*5.x, 4.4*
 |===
+
+##### Notes:
+
+- `GA` denotes Neo4j 5.1 was the first General Availability (GA) release version, being publicly available for all customers to use.
+- `LA` denotes that Neo4j 5.0 was a Limited Availabilty release only and was released to specific customers.
 
 ---
 
@@ -30,12 +35,16 @@ Review our https://neo4j.com/terms/support-terms-pre-neo4j-5/[Neo4j Pre-5.x Supp
 [options=header]
 |===
 |Release |Release Date |End of Support Date |Compatible Driver Versions 
-|[white]*4.4*(n1) |[white]*December 2, 2021* |[white]*December 1, 2024* |[white]*5.x, 4.4, 4.3, 4.2, 4.1, 4.0* 
+|[white]*4.4* `LTS` |[white]*December 2, 2021* |[white]*December 1, 2024* |[white]*5.x, 4.4, 4.3, 4.2, 4.1, 4.0* 
 |[white]*4.3* |[white]*June 17, 2021* |[white]*December 16, 2022* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
 |[white]*4.2* |[white]*November 17, 2020* |[white]*May 16, 2022* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
 |[white]*4.1* |[white]*June 23, 2020* |[white]*December 22, 2021* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
 |[white]*4.0* |[white]*January 15, 2020* |[white]*July 14, 2021* |[white]*4.4, 4.3, 4.2, 4.1, 4.0* 
 |===
+
+##### Notes:
+
+- `LTS` denotes this is the final version within a major release family and is supported for a longer duration than standard releases.
 
 ---
 
@@ -44,8 +53,8 @@ Review our https://neo4j.com/terms/support-terms-pre-neo4j-5/[Neo4j Pre-5.x Supp
 [options=header]
 |===
 |Release |Release Date |End of Support Date |Compatible Driver Versions 
-|[white]*3.5*(n1) |[white]*November 29, 2018* |[white]*May 27, 2022* (n3) |[white]*4.4, 4.3, 4.2, 4.1, 4.0, 1.7* 
-|[white]*3.4* |[white]*May 17, 2018* |[white]*March 31, 2020* (n2) |[white]*1.7, 1.6* 
+|[white]*3.5*`n1` |[white]*November 29, 2018* |[white]*May 27, 2022* `n3` |[white]*4.4, 4.3, 4.2, 4.1, 4.0, 1.7* 
+|[white]*3.4* |[white]*May 17, 2018* |[white]*March 31, 2020* `n2` |[white]*1.7, 1.6* 
 |[white]*3.3* |[white]*October 24, 2017* |[white]*April 28, 2019* |[white]*1.7, 1.6, 1.5, 1.4* 
 |[white]*3.2* |[white]*May 11, 2017* |[white]*November 31, 2018* |[white]*1.6, 1.5, 1.4, 1.3* 
 |[white]*3.1* |[white]*December 13, 2016* |[white]*June 13, 2018* |[white]*1.6, 1.5, 1.4, 1.3, 1.2, 1.1* 
@@ -66,13 +75,12 @@ Review our https://neo4j.com/terms/support-terms-pre-neo4j-5/[Neo4j Pre-5.x Supp
 |[white]*1.0* |[white]*February 23, 2010* |[white]*August 23, 2011* | 
 |===
 
-(n1) Note: Last minor version of the major version.
 
+##### Notes:
 
-(n2) Note: One-time extension for 3.4 only.
-
-
-(n3) Note: One-time extension for 3.5 only.
+- `n1` Last minor version of the major version.
+- `n2` One-time extension for 3.4 only.
+- `n3` One-time extension for 3.5 only.
 
 
 The driver major.minor version number describes the feature set available within that driver. Across languages, drivers are generally 


### PR DESCRIPTION
Added GA/LA/LTS labels for launch version docs.