### PR TITLE
Disable Git -> ZD KB overwriting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [ master ]
+#    branches: [ master ]
 
 jobs:
   publish:


### PR DESCRIPTION
Now that support are doing KB management on ZD directly and not Git, we don't want to overwrite the KBs being published from here.